### PR TITLE
alpha order readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <!-- prettier-ignore-end -->
 
-[Türkçe](README_TR.md)
+[English](README.md)
 &nbsp;
 [عربي](README_AR.md)
 &nbsp;
 [Español](README_ES.md)
-
+&nbsp;
+[Türkçe](README_TR.md)
 </div>
 
 Welcome to <a href="https://onelang.org">One</a>!</br>

--- a/README_AR.md
+++ b/README_AR.md
@@ -32,9 +32,11 @@
 
 [English](README.md)
 &nbsp;
-[Türkçe](README_TR.md)
+[عربي](README_AR.md)
 &nbsp;
 [Español](README_ES.md)
+&nbsp;
+[Türkçe](README_TR.md)
 
 </div>
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -30,9 +30,11 @@
 
 [English](README.md)
 &nbsp;
-[Türkçe](README_TR.md)
-&nbsp;
 [عربي](README_AR.md)
+&nbsp;
+[Español](README_ES.md)
+&nbsp;
+[Türkçe](README_TR.md)
 
 </div>
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -33,6 +33,8 @@
 [عربي](README_AR.md)
 &nbsp;
 [Español](README_ES.md)
+&nbsp;
+[Türkçe](README_TR.md)
 
 </div>
 


### PR DESCRIPTION
Links to readme pages are ordered alphabetically on each readme page. fixes #143 