### PR TITLE
ignore arabic md file from spell checker

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install
         run: wget -O - -q https://git.io/misspell | sh -s -- -b .
       - name: Misspell
-        run: git ls-files --empty-directory | grep -v README_TR.md | grep -v README_ES.md | xargs ./misspell -error
+        run: git ls-files --empty-directory | grep -v README_TR.md | grep -v README_ES.md | grep -v README_AR.md | xargs ./misspell -error
   pre-commit:
     name: Run pre-commit  # https://pre-commit.com/
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         name: Run codespell
         description: Check spelling with codespell
         entry: codespell --ignore-words=codespell.txt
-        exclude: ^README_TR\.md$|^README_ES\.md$
+        exclude: ^README_TR\.md$|^README_ES\.md$|^README_AR\.md$
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.27.1
     hooks:


### PR DESCRIPTION
Edited `.pre-commit-config.yaml` and `lint.yml` files to ignore the Arabic README page from the spell checker. Fixes #158 