### PR TITLE
Remove All Contributors from the French README

### DIFF
--- a/README_FR.md
+++ b/README_FR.md
@@ -25,12 +25,6 @@
 [![License][licensebadge]][licenseurl]
 [![Facebook][facebookbadge]][facebookurl]
 
-<!-- prettier-ignore-start -->
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-18-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-<!-- prettier-ignore-end -->
-
 [English](README.md)
 &nbsp;
 [عربي](README_AR.md)


### PR DESCRIPTION
All Contributors is only shown on the English README

24 on the English and 18 on the French so it doesn't seem to update or work

https://github.com/One-Language/One/blob/main/README_FR.md