### PR TITLE
Revert "Run pre-commit without --all-files option (#368)"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,4 +43,4 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
-        run: pre-commit
+        run: pre-commit run --all-files


### PR DESCRIPTION
This reverts commit 7abb1f87f6c970fbb109f069b9eac0d4f371abdf.