### PR TITLE
Use lowercase HTTP header field names to be compatible with HTTP/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -215,16 +215,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_AR.md
+++ b/docs/README_AR.md
@@ -210,8 +210,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -237,16 +237,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -190,8 +190,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -213,16 +213,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_FA.md
+++ b/docs/README_FA.md
@@ -215,8 +215,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -242,16 +242,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_FIL.md
+++ b/docs/README_FIL.md
@@ -190,8 +190,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -213,16 +213,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -189,8 +189,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -212,16 +212,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_IT.md
+++ b/docs/README_IT.md
@@ -191,8 +191,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -214,16 +214,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -191,8 +191,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -214,16 +214,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_KR.md
+++ b/docs/README_KR.md
@@ -191,8 +191,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -214,16 +214,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -190,8 +190,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -213,16 +213,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_TR.md
+++ b/docs/README_TR.md
@@ -190,8 +190,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -213,16 +213,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/docs/README_UK.md
+++ b/docs/README_UK.md
@@ -190,8 +190,8 @@ home {
     _ "Hi, Welcome"
 }
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ "<h1>404></h1>"
 }
 main {
@@ -213,16 +213,16 @@ main {
 
 ```c
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     _ `<!doctype html><html><head><title>Error 404</title><meta charset="utf-8"></head><body><h1>404></h1></body></html>`
 }
 
 vs
 
 error {
-    headers.add('HTTP-Type: 404')
-    headers.add('Content-Type: text/html;charset=utf-8')
+    headers.add('HTTP/1.0 404 Not Found')
+    headers.add('content-type: text/html;charset=utf-8')
     page {
         title: 'Error 404'
         label {

--- a/tmp/c-new/tests/33-web-cgi.et
+++ b/tmp/c-new/tests/33-web-cgi.et
@@ -6,7 +6,7 @@ void main()
         //cgi.type("text/html");
         //cgi.format("html");//auto detect html is alias of `text/html`
         //cgi.charset("utf-8");
-        _ "Content-Type: text/html; charset=utf-8\r\n\r\n";
+        _ "content-type: text/html; charset=utf-8\r\n\r\n";
         _ "Hello World!";
     }
 }


### PR DESCRIPTION
"Just as in HTTP/1.x, header field names are strings of ASCII characters that are compared in a case-insensitive fashion. However, header field names MUST be converted to lowercase prior to their encoding in HTTP/2. A request or response containing uppercase header field names MUST be treated as malformed (Section 8.1.2.6)."

https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2

https://web.dev/performance-http2/

