### PR TITLE
Remove misspell

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,16 +18,6 @@ jobs:
           check-modified-files-only: 'yes'
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'
-  misspell:
-    name: Check Spelling Misspell All Files In Commit
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v3
-      - name: Install
-        run: wget -O - -q https://git.io/misspell | sh -s -- -b .
-      - name: Misspell
-        run: git ls-files --empty-directory | grep -v docs/ | xargs ./misspell -error
   pre-commit:
     name: Run pre-commit  # https://pre-commit.com/
     runs-on: ubuntu-latest


### PR DESCRIPTION
It looks like misspell is no longer maintained and the last commit was on Mar 9, 2018.

We already run codespell and it is an active project with the last commit 5 days ago.