### PR TITLE
Fix Super-Linter action path

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
-      - uses: github/super-linter/slim@v5.0.0
+      - uses: super-linter/super-linter/slim@v5.0.0
         env:
           DEFAULT_BRANCH: main
           ERROR_ON_MISSING_EXEC_BIT: true


### PR DESCRIPTION
https://github.com/super-linter/super-linter

https://github.com/marketplace/actions/super-linter

They changed the organization name to "super-linter" from "github" for the Super-Linter Action