### PR TITLE
actions: remove workflow markdown link check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,18 +6,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
-  markdown-link-check:
-    name: Check for broken links in Markdown files
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          base-branch: 'main'
-          check-modified-files-only: 'yes'
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
   pre-commit:
     name: Run pre-commit  # https://pre-commit.com/
     runs-on: ubuntu-latest


### PR DESCRIPTION
We are already running the markdown link check with pre-commit

https://github.com/One-Language/One/blob/bd19cd3bf59e5484fa10aa7fee4c006be9901f60/.pre-commit-config.yaml#L96