### PR TITLE
Update CI matrix to remove ubuntu-20.04

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,6 @@ jobs:
       matrix:
         include:
           - {os: ubuntu-latest}
-          - {os: ubuntu-20.04}
           - {os: macos-latest}
           - {os: windows-latest}
     steps:


### PR DESCRIPTION
Removed ubuntu-20.04 from the CI matrix.