### PR TITLE
Fix Super-Linter markdown lint

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,5 +1,4 @@
 # https://github.com/DavidAnson/markdownlint#rules--aliases
-# markdownlint -c .github/linters/.markdown-lint.yml .
 
 # MD001/heading-increment/header-increment Heading levels should only increment by one level at a time
 MD001: false
@@ -21,3 +20,6 @@ MD040: false
 
 # MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading
 MD041: false
+
+# MD059/descriptive-link-text Link text should be descriptive
+MD059: false


### PR DESCRIPTION
Disable MD059 rule in markdown-lint configuration